### PR TITLE
spcr-settings: fix finding the advanced settings button and allow passing in settings in constructor

### DIFF
--- a/packages/spcr-settings/settingsSection.tsx
+++ b/packages/spcr-settings/settingsSection.tsx
@@ -1,13 +1,14 @@
 import React, { useState } from 'react'
 import ReactDOM from 'react-dom';
 import styles from './settings.module.css'
+import { ISettingsField, NewValueTypes } from './types/settings-field';
 
 class SettingsSection {
-  settingsFields: {[nameId: string]: ISettingsField} = {};
+  settingsFields: { [nameId: string]: ISettingsField } = this.initialSettingsFields;
   private stopHistoryListener: any;
   private setRerender: Function | null = null;
 
-  constructor(public name: string, public settingsId: string) { }
+  constructor(public name: string, public settingsId: string, public initialSettingsFields: { [key: string]: ISettingsField } = {}) {}
 
   pushSettings = async () => {
     Object.entries(this.settingsFields).forEach(([nameId, field]) => {
@@ -90,7 +91,7 @@ class SettingsSection {
   addButton = (nameId: string, description: string, value: string, onClick?: () => void) => {
     this.settingsFields[nameId] = {
       type: "button",
-      description: description,
+      description,
       defaultValue: value,
       callback: onClick,
     };
@@ -99,8 +100,8 @@ class SettingsSection {
   addInput = (nameId: string, description: string, defaultValue: string, onChange?: () => void) => {
     this.settingsFields[nameId] = {
       type: "input",
-      description: description,
-      defaultValue: defaultValue,
+      description,
+      defaultValue,
       callback: onChange,
     };
   }
@@ -136,7 +137,7 @@ class SettingsSection {
   }
 
   setFieldValue = (nameId: string, newValue: any) => {
-    Spicetify.LocalStorage.set(`${this.settingsId}.${nameId}`, JSON.stringify({value:newValue}));
+    Spicetify.LocalStorage.set(`${this.settingsId}.${nameId}`, JSON.stringify({ value: newValue }));
   }
 
   private FieldsContainer = () => {
@@ -151,7 +152,7 @@ class SettingsSection {
     </div>
   }
 
-  private Field = (props: {nameId: string, field: ISettingsField}) => {
+  private Field = (props: { nameId: string, field: ISettingsField }) => {
     const id = `${this.settingsId}.${props.nameId}`;
     
     let defaultStateValue;
@@ -167,13 +168,13 @@ class SettingsSection {
 
     const [value, setValueState] = useState(defaultStateValue);
     
-    const setValue = (newValue?: any) => {
+    const setValue = (newValue?: NewValueTypes) => {
       if (newValue !== undefined) {
         setValueState(newValue);
         this.setFieldValue(props.nameId!, newValue);
       }
       if (props.field.callback)
-        props.field.callback();
+        props.field.callback(newValue);
     }
 
     return <>
@@ -221,14 +222,6 @@ class SettingsSection {
       </span>
     </>
   }
-}
-
-interface ISettingsField {
-  type: "button" | "toggle" | "input" | "dropdown" | "hidden",
-  description?: string,
-  defaultValue: any,
-  callback?: () => void,
-  options?: string[],
 }
 
 export { SettingsSection };

--- a/packages/spcr-settings/settingsSection.tsx
+++ b/packages/spcr-settings/settingsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { KeyboardEventHandler, useState } from 'react'
 import ReactDOM from 'react-dom';
 import styles from './settings.module.css'
 import { ISettingsField, NewValueTypes } from './types/settings-field';
@@ -177,6 +177,16 @@ class SettingsSection {
         props.field.callback(newValue);
     }
 
+    const onKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
+      if (props.field.keyDown)
+        props.field.keyDown(e);
+    }
+
+    const onBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
+      if (props.field.blur)
+        props.field.blur(e);
+    }
+
     return <>
       <div className="main-type-mesto" style={{color: 'var(--spice-subtext)'}}><label htmlFor={id}>
         {props.field.description || ""}
@@ -184,9 +194,16 @@ class SettingsSection {
       <span className="x-settings-secondColumn">
         {
           props.field.type === 'input' ? 
-            <input className="main-dropDown-dropDown" id={id} dir="ltr" value={value as string} type={"text"} onChange={(e) => {
-              setValue(e.currentTarget.value);
-            }} /> :
+            <input
+              className="main-dropDown-dropDown"
+              id={id}
+              dir="ltr"
+              value={value as string}
+              type="text"
+              onKeyDown={onKeyDown}
+              onBlur={onBlur}
+              onChange={(e) => { setValue(e.currentTarget.value) } }
+            /> :
 
           props.field.type === 'button' ? 
             <span className="">

--- a/packages/spcr-settings/settingsSection.tsx
+++ b/packages/spcr-settings/settingsSection.tsx
@@ -3,14 +3,14 @@ import ReactDOM from 'react-dom';
 import styles from './settings.module.css'
 
 class SettingsSection {
-  settingsFields: {[nameId: string]: ISettingsField} = { };
+  settingsFields: {[nameId: string]: ISettingsField} = {};
   private stopHistoryListener: any;
   private setRerender: Function | null = null;
 
   constructor(public name: string, public settingsId: string) { }
 
   pushSettings = async () => {
-    Object.entries(this.settingsFields).map(([nameId, field]) => {
+    Object.entries(this.settingsFields).forEach(([nameId, field]) => {
       if (field.type !== 'button' && this.getFieldValue(nameId) === undefined) {
         this.setFieldValue(nameId, field.defaultValue);
       }
@@ -47,38 +47,30 @@ class SettingsSection {
     }
 
     const allSettingsContainer = document.getElementsByClassName('x-settings-container')[0];
-    let pluginSettingsContainer: Element | null = null;
-  
-    for (let i = 0; i < allSettingsContainer.children.length; i++) {
-      if (allSettingsContainer.children[i].id === this.settingsId) {
-        pluginSettingsContainer = allSettingsContainer.children[i];
-      }
-    }
+    let pluginSettingsContainer = Array.from(allSettingsContainer.children).find((child) => child.id === this.settingsId)
   
     if (!pluginSettingsContainer) {
       pluginSettingsContainer = document.createElement('div');
       pluginSettingsContainer.id = this.settingsId;
       pluginSettingsContainer.className = styles.settingsContainer;
-      let advancedOptionsButton: Element | null = null;
+      let advancedOptionsButton: Element | undefined = undefined;
       let tries = 0;
 
       // Loop until "show advanced settings" button is found.
       while (true) {
         try {
           const buttons = allSettingsContainer.getElementsByClassName('x-settings-button');
-          for (let i = 0; i < buttons.length; i++) {
-            if (buttons[i].children[0]?.textContent?.toLowerCase().endsWith('advanced settings')) {
-              advancedOptionsButton = buttons[i];
-              break;
-            }
-          }
+          advancedOptionsButton = Array.from(buttons).find((button) => {
+            return button.children[0]?.textContent?.toLowerCase().endsWith('advanced settings')
+          })
         } catch (e) {
           console.error("Error while finding \"show advanced settings\" button:", e);
         }
         
         if (advancedOptionsButton) break
+        
         if (Spicetify.Platform.History.location.pathname !== '/preferences') {
-          console.log(`Couldn't find \"show advanced settings\" button after ${tries} tries.`);
+          console.warn(`[spcr-settings] couldn't find "show advanced settings" button after ${tries} tries.`);
           return;
         }
 
@@ -229,8 +221,6 @@ class SettingsSection {
       </span>
     </>
   }
-
-
 }
 
 interface ISettingsField {

--- a/packages/spcr-settings/settingsSection.tsx
+++ b/packages/spcr-settings/settingsSection.tsx
@@ -91,7 +91,7 @@ class SettingsSection {
   addButton = (nameId: string, description: string, value: string, onClick?: () => void, events?: ISettingsFieldButton['events']) => {
     this.settingsFields[nameId] = {
       type: "button",
-      description,
+      description: description,
       value: value,
       events: {
         onClick: onClick,
@@ -103,8 +103,8 @@ class SettingsSection {
   addInput = (nameId: string, description: string, defaultValue: string, onChange?: () => void, events?: ISettingsFieldInput['events']) => {
     this.settingsFields[nameId] = {
       type: "input",
-      description,
-      defaultValue,
+      description: description,
+      defaultValue: defaultValue,
       events: {
         onChange: onChange,
         ...events,

--- a/packages/spcr-settings/settingsSection.tsx
+++ b/packages/spcr-settings/settingsSection.tsx
@@ -1,7 +1,7 @@
 import React, { KeyboardEventHandler, useState } from 'react'
 import ReactDOM from 'react-dom';
 import styles from './settings.module.css'
-import { ISettingsField, NewValueTypes } from './types/settings-field';
+import { ISettingsField, ISettingsFieldDropdown, ISettingsFieldInput, NewValueTypes } from './types/settings-field';
 
 class SettingsSection {
   settingsFields: { [nameId: string]: ISettingsField } = this.initialSettingsFields;
@@ -97,12 +97,13 @@ class SettingsSection {
     };
   }
 
-  addInput = (nameId: string, description: string, defaultValue: string, onChange?: () => void) => {
+  addInput = (nameId: string, description: string, defaultValue: string, onChange?: () => void, events?: ISettingsFieldInput['events']) => {
     this.settingsFields[nameId] = {
       type: "input",
       description,
       defaultValue,
       callback: onChange,
+      events,
     };
   }
 
@@ -168,23 +169,13 @@ class SettingsSection {
 
     const [value, setValueState] = useState(defaultStateValue);
     
-    const setValue = (newValue?: NewValueTypes) => {
+    const setValue = (newValue?: any) => {
       if (newValue !== undefined) {
         setValueState(newValue);
         this.setFieldValue(props.nameId!, newValue);
       }
-      if (props.field.callback)
+      if (props.field.type !== 'hidden' && props.field.callback)
         props.field.callback(newValue);
-    }
-
-    const onKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
-      if (props.field.keyDown)
-        props.field.keyDown(e);
-    }
-
-    const onBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
-      if (props.field.blur)
-        props.field.blur(e);
     }
 
     return <>
@@ -200,9 +191,8 @@ class SettingsSection {
               dir="ltr"
               value={value as string}
               type="text"
-              onKeyDown={onKeyDown}
-              onBlur={onBlur}
               onChange={(e) => { setValue(e.currentTarget.value) } }
+              {...props.field.events}
             /> :
 
           props.field.type === 'button' ? 
@@ -227,10 +217,10 @@ class SettingsSection {
           
           props.field.type === 'dropdown' ?
             <select className="main-dropDown-dropDown" id={id} onChange={(e) => {
-              setValue(props.field.options![e.currentTarget.selectedIndex])
+              setValue((props.field as ISettingsFieldDropdown).options[e.currentTarget.selectedIndex])
             }}>
               {
-                props.field.options!.map((option, i) => {
+                props.field.options.map((option, i) => {
                   return <option selected={option === value} value={i+1}>{option}</option>
                 })
               }

--- a/packages/spcr-settings/settingsSection.tsx
+++ b/packages/spcr-settings/settingsSection.tsx
@@ -61,7 +61,7 @@ class SettingsSection {
         try {
           const buttons = allSettingsContainer.getElementsByClassName('x-settings-button');
           advancedOptionsButton = Array.from(buttons).find((button) => {
-            return button.children[0]?.textContent?.toLowerCase().endsWith('advanced settings')
+            return (button.children[0] as HTMLButtonElement)?.type === 'button';
           })
         } catch (e) {
           console.error("Error while finding \"show advanced settings\" button:", e);

--- a/packages/spcr-settings/types/settings-field.ts
+++ b/packages/spcr-settings/types/settings-field.ts
@@ -1,0 +1,9 @@
+export interface ISettingsField {
+    type: "button" | "toggle" | "input" | "dropdown" | "hidden",
+    description?: string,
+    defaultValue: any,
+    options?: string[],
+    callback?: (newValue?: NewValueTypes) => void,
+}
+
+export type NewValueTypes = boolean | string;

--- a/packages/spcr-settings/types/settings-field.ts
+++ b/packages/spcr-settings/types/settings-field.ts
@@ -1,12 +1,42 @@
-export interface ISettingsField {
-    type: "button" | "toggle" | "input" | "dropdown" | "hidden",
+export interface ISettingsFieldHidden {
+    type: "hidden",
+    defaultValue: any,
+}
+
+export interface ISettingsFieldInput {
+    type: "input",
     description?: string,
     defaultValue: any,
-    options?: string[],
-    callback?: (newValue?: NewValueTypes) => void,
-    /** The following events are only emitted when 'type' is input */
-    keyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void,
-    blur?: (event: React.FocusEvent<HTMLInputElement, Element>) => void,
+    callback?: (newValue?: string) => void,
+    events?: Partial<React.InputHTMLAttributes<HTMLInputElement>>,
 }
+
+export interface ISettingsFieldDropdown {
+    type: "dropdown",
+    description?: string,
+    defaultValue: string,
+    options: string[],
+    callback?: (newValue?: string) => void,
+}
+
+export interface ISettingsFieldButton {
+    type: "button",
+    description?: string,
+    defaultValue: any,
+    callback?: (newValue?: unknown) => void,
+}
+
+export interface ISettingsFieldGenericToggle {
+    type: "toggle",
+    description?: string,
+    defaultValue: boolean,
+    callback?: (newValue?: boolean) => void,
+}
+
+export type ISettingsField = ISettingsFieldHidden
+    | ISettingsFieldDropdown
+    | ISettingsFieldInput
+    | ISettingsFieldButton
+    | ISettingsFieldGenericToggle;
 
 export type NewValueTypes = boolean | string;

--- a/packages/spcr-settings/types/settings-field.ts
+++ b/packages/spcr-settings/types/settings-field.ts
@@ -7,7 +7,6 @@ export interface ISettingsFieldInput {
     type: "input",
     description?: string,
     defaultValue: any,
-    callback?: (newValue?: string) => void,
     events?: Partial<React.InputHTMLAttributes<HTMLInputElement>>,
 }
 
@@ -16,27 +15,27 @@ export interface ISettingsFieldDropdown {
     description?: string,
     defaultValue: string,
     options: string[],
-    callback?: (newValue?: string) => void,
+    events?: Partial<React.SelectHTMLAttributes<HTMLSelectElement>>,
 }
 
 export interface ISettingsFieldButton {
     type: "button",
     description?: string,
-    defaultValue: any,
-    callback?: (newValue?: unknown) => void,
+    value: any,
+    events?: Partial<React.ButtonHTMLAttributes<HTMLButtonElement>>,
 }
 
-export interface ISettingsFieldGenericToggle {
+export interface ISettingsFieldToggle {
     type: "toggle",
     description?: string,
     defaultValue: boolean,
-    callback?: (newValue?: boolean) => void,
+    events?: Partial<React.InputHTMLAttributes<HTMLInputElement>>,
 }
 
 export type ISettingsField = ISettingsFieldHidden
     | ISettingsFieldDropdown
     | ISettingsFieldInput
     | ISettingsFieldButton
-    | ISettingsFieldGenericToggle;
+    | ISettingsFieldToggle;
 
 export type NewValueTypes = boolean | string;

--- a/packages/spcr-settings/types/settings-field.ts
+++ b/packages/spcr-settings/types/settings-field.ts
@@ -4,6 +4,9 @@ export interface ISettingsField {
     defaultValue: any,
     options?: string[],
     callback?: (newValue?: NewValueTypes) => void,
+    /** The following events are only emitted when 'type' is input */
+    keyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void,
+    blur?: (event: React.FocusEvent<HTMLInputElement, Element>) => void,
 }
 
 export type NewValueTypes = boolean | string;


### PR DESCRIPTION
This PR does the following:
* Fix finding the settings button in a non english UI (code was looking for some english text, but my spotify is set to Dutch)
* Allow passing in settings into the constructor. In my opinion calling a function for every setting item was a bit cumbersome.
* Add `keyDown` and `blur` events to the input field
* Refactor some `for` loops to es6 array functions