### PR TITLE
Fix wrong spotify version check

### DIFF
--- a/packages/spcr-settings/settingsSection.tsx
+++ b/packages/spcr-settings/settingsSection.tsx
@@ -61,7 +61,7 @@ class SettingsSection {
 
       // Only loop until "show advanced settings" button is found if
       // spotify version < 1.1.80
-      if (spotifyVersion < 80) {
+      if (spotifyVersion >= 80) {
         allSettingsContainer.appendChild(pluginSettingsContainer);
       } else {
         while (true) {


### PR DESCRIPTION
Fix for #2 and #3 f-up

The spotify version check was `spotifyVersion < 80` when it should have been `spotifyVersion >= 80`.