### PR TITLE
fix(spcr-settings): settings container not being found & styling improvements

### DIFF
--- a/packages/spcr-settings/settingsSection.tsx
+++ b/packages/spcr-settings/settingsSection.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import ReactDOM from 'react-dom';
 import styles from './settings.module.css'
 import { ISettingsField, ISettingsFieldButton, ISettingsFieldDropdown, ISettingsFieldInput, ISettingsFieldToggle, NewValueTypes } from './types/settings-field';
+import './styles.css';
 
 class SettingsSection {
   settingsFields: { [nameId: string]: ISettingsField } = this.initialSettingsFields;
@@ -47,7 +48,9 @@ class SettingsSection {
       await new Promise(resolve => setTimeout(resolve, 100));
     }
 
-    const allSettingsContainer = document.getElementsByClassName('x-settings-container')[0];
+    const allSettingsContainer = document.querySelector('.main-view-container__scroll-node-child main div');
+    if (!allSettingsContainer) return console.error('[spcr-settings] settings container not found');
+
     let pluginSettingsContainer = Array.from(allSettingsContainer.children).find((child) => child.id === this.settingsId)
   
     if (!pluginSettingsContainer) {
@@ -173,7 +176,7 @@ class SettingsSection {
     this.setRerender = setRerender;
 
     return <div className={styles.settingsContainer} key={rerender}>
-      <h2 className="main-shelf-title main-type-cello">{this.name}</h2>
+      <h2 className="main-shelf-title main-type-cello spcr-settings-heading">{this.name}</h2>
       {Object.entries(this.settingsFields).map(([nameId, field]) => {
         return <this.Field nameId={nameId} field={field} />
       })}
@@ -204,10 +207,10 @@ class SettingsSection {
     }
 
     return <>
-      <div className="main-type-mesto" style={{color: 'var(--spice-subtext)'}}><label htmlFor={id}>
-        {props.field.description || ""}
-      </label></div>
-      <span className="x-settings-secondColumn">
+      <div className="main-type-mesto" style={{color: 'var(--spice-subtext)'}}>
+        <label className="spcr-settings-description" htmlFor={id}>{props.field.description || ""}</label>
+      </div>
+      <span className="x-settings-secondColumn spcr-setting-input-wrapper">
         {
           props.field.type === 'input' ? 
             <input

--- a/packages/spcr-settings/styles.css
+++ b/packages/spcr-settings/styles.css
@@ -1,0 +1,17 @@
+.spcr-settings-heading {
+  grid-column: 1/-1;
+  font-size: 1.125rem;
+  line-height: 1.5rem;
+  color: #fff;
+  margin-top: 24px;
+}
+
+.spcr-settings-description {
+   font-size: 0.875rem;
+   line-height: 1.25rem;
+}
+
+.spcr-setting-input-wrapper {
+   display: flex;
+   justify-self: end;
+}


### PR DESCRIPTION
Spotify 1.1.83 introduced some changes in the classnames and styling used for the settings page. This broke spcr-settings, because it wasn't able to find the settings container, and also broke some styling (layout wasn't correct anymore after fixing the settings container not being found).

This PR fixes the settings container not being found, and thus not rendering spcr-settings. It also fixes the styling that 'broke'. It also makes some small changes in styling (mainly text), to be more consistent with Spotify's styling.